### PR TITLE
add newline to end of description

### DIFF
--- a/src/commands/gen.ts
+++ b/src/commands/gen.ts
@@ -10,8 +10,8 @@ const writeLine = (entry: ChangelogEntry): string => {
     if (entry.author?.email) {
       line += ` (${entry.author?.email})`;
     }
-    line += "\n";
   }
+  line += "\n";
   return line;
 };
 


### PR DESCRIPTION
This was a bug where I didn't make a newline, causing all of the descriptions to be on a single line.